### PR TITLE
[バグ修正] Chrome, Safari で不必要な span が作成された状態でも見出しを作成できるように修正

### DIFF
--- a/dist/js/medium-editor.js
+++ b/dist/js/medium-editor.js
@@ -975,6 +975,10 @@ MediumEditor.extensions = {};
                 }
             }
 
+            // 不必要なspanを消す為に、内部のテキストをinnerHTMLに置く
+            const rawText = blockContainer.innerText || blockContainer.textContent;
+            blockContainer.innerHTML = rawText;
+
             return doc.execCommand('formatBlock', false, tagName);
         },
 
@@ -7181,6 +7185,10 @@ MediumEditor.extensions = {};
             }
 
             return result;
+        }
+
+        if (action === 'createHeader') {
+          return MediumEditor.pasteHTML('<h1>hoge</h1>')
         }
 
         cmdValueArgument = opts && opts.value;

--- a/dist/js/medium-editor.js
+++ b/dist/js/medium-editor.js
@@ -7187,10 +7187,6 @@ MediumEditor.extensions = {};
             return result;
         }
 
-        if (action === 'createHeader') {
-          return MediumEditor.pasteHTML('<h1>hoge</h1>')
-        }
-
         cmdValueArgument = opts && opts.value;
         return this.options.ownerDocument.execCommand(action, false, cmdValueArgument);
     }


### PR DESCRIPTION
https://github.com/openpage-jp/OpenPage/issues/1661 の修正

[バグ修正] Chrome, Safari で不必要な span が作成された状態でも見出しを作成できるように修正しました